### PR TITLE
Improvement:  ik clavicle now builds on joints that aren't aligned to world. 

### DIFF
--- a/character/human/body/.code/rig/arms/ik_clavicle/ik_clavicle.py
+++ b/character/human/body/.code/rig/arms/ik_clavicle/ik_clavicle.py
@@ -78,21 +78,19 @@ def main():
         
         #fix pole vector
         loc = cmds.spaceLocator(n = 'clavicle_rotateLock_%s' % side)[0]
+        locXform = cmds.group(loc ,n = 'xform_clavicle_rotateLock_%s' % side)
 
         if side =='L':
             left_loc = loc
-            space.MatchSpace(section[0],loc).translation_rotation()
-            cmds.makeIdentity(loc, apply = True, t = True, r = True)
+            space.MatchSpace(section[0],locXform).translation_rotation()
             pole_value = cmds.getAttr('%s.poleVector' % handle)[0]
             
             cmds.setAttr('%s.translateX' % loc, pole_value[0])
             cmds.setAttr('%s.translateY' % loc, pole_value[1])
             cmds.setAttr('%s.translateZ' % loc, pole_value[2])
             
-        cmds.parent(loc, driver)
+        cmds.parent(locXform, driver)
         if side == 'R':
-            space.mirror_xform(left_loc)
+            space.mirror_xform(left_loc, locXform)
 
-        cmds.poleVectorConstraint(loc, handle) 
-        
-        
+        cmds.poleVectorConstraint(loc, handle)         

--- a/character/human/body/.code/rig/arms/ik_clavicle/ik_clavicle.py
+++ b/character/human/body/.code/rig/arms/ik_clavicle/ik_clavicle.py
@@ -78,19 +78,19 @@ def main():
         
         #fix pole vector
         loc = cmds.spaceLocator(n = 'clavicle_rotateLock_%s' % side)[0]
-        locXform = cmds.group(loc ,n = 'xform_clavicle_rotateLock_%s' % side)
+        loc_xform = space.create_xform_group(loc)
 
         if side =='L':
             left_loc = loc
-            space.MatchSpace(section[0],locXform).translation_rotation()
+            space.MatchSpace(section[0],loc_xform).translation_rotation()
             pole_value = cmds.getAttr('%s.poleVector' % handle)[0]
             
             cmds.setAttr('%s.translateX' % loc, pole_value[0])
             cmds.setAttr('%s.translateY' % loc, pole_value[1])
             cmds.setAttr('%s.translateZ' % loc, pole_value[2])
             
-        cmds.parent(locXform, driver)
+        cmds.parent(loc_xform, driver)
         if side == 'R':
-            space.mirror_xform(left_loc, locXform)
+            space.mirror_xform(left_loc, loc_xform)
 
         cmds.poleVectorConstraint(loc, handle)         


### PR DESCRIPTION
My shoulders were not worldspace oriented, so when the code freeze transformation in line 85, it was setting the "clavicle_rotateLock_" to a worldspace orietation that was causing the locator not matching with the position of the pole vector and flipping the shoulder

By add a xform group instead of the freeze transformation, it works in any orientation.